### PR TITLE
Add favicon and profile photo to index

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,12 @@
           <!DOCTYPE html>
           <html lang="en">
           <head>
-              <meta charset="UTF-8">
-              <meta name="viewport" content="width=device-width, initial-scale=1.0">
-              <title>Bennett Stouffer - Resume</title>
-              <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-              <style>
+                <meta charset="UTF-8">
+                <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                <title>Bennett Stouffer - Resume</title>
+                <link rel="icon" href="/assets/img/favicon.ico">
+                <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+                <style>
                   /* Custom CSS for additional styling */
                   body {
                       font-family: 'Open Sans', sans-serif;
@@ -36,10 +37,11 @@
               </header>
 
               <main class="pt-16">
-                  <section id="about" class="container mx-auto my-8">
-                      <h2 class="text-3xl font-bold mb-4">About Me</h2>
-                      <p>I am Bennett Stouffer, a dedicated and skilled professional with a passion for design, engineering, and technology. With expertise in design tools, practical skills, and programming languages, I excel in creating innovative solutions and enhancing efficiency in the engineering domain.</p>
-                  </section>
+                <section id="about" class="container mx-auto my-8">
+                    <h2 class="text-3xl font-bold mb-4">About Me</h2>
+                    <img src="/assets/img/profile.jpg" alt="Bennett Stouffer">
+                    <p>I am Bennett Stouffer, a dedicated and skilled professional with a passion for design, engineering, and technology. With expertise in design tools, practical skills, and programming languages, I excel in creating innovative solutions and enhancing efficiency in the engineering domain.</p>
+                </section>
 
                   <section id="skills" class="container mx-auto my-8">
                       <h2 class="text-3xl font-bold mb-4">Skills</h2>


### PR DESCRIPTION
## Summary
- Include site favicon in the HTML head
- Display profile photo in the About Me section

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897f9cbd2e48330ae16a1f8efe1439e