### PR TITLE
Add meta description and Google Fonts link

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,9 @@
           <head>
               <meta charset="UTF-8">
               <meta name="viewport" content="width=device-width, initial-scale=1.0">
+              <meta name="description" content="Short summary of Bennett Stouffer’s experience and skills">
               <title>Bennett Stouffer - Resume</title>
+              <link href="https://fonts.googleapis.com/css2?family=Open+Sans&display=swap" rel="stylesheet">
               <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
               <style>
                   /* Custom CSS for additional styling */


### PR DESCRIPTION
## Summary
- add meta description for Bennett Stouffer's site
- load Open Sans from Google Fonts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897f9d2c59483308b49f5b4a07b0d0f