### PR TITLE
refactor: externalize styles and scripts

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -1,0 +1,12 @@
+/* Custom CSS for additional styling */
+body {
+    font-family: 'Open Sans', sans-serif;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+.experience-list, .education-list {
+    list-style-type: square;
+}

--- a/index.html
+++ b/index.html
@@ -5,20 +5,7 @@
               <meta name="viewport" content="width=device-width, initial-scale=1.0">
               <title>Bennett Stouffer - Resume</title>
               <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-              <style>
-                  /* Custom CSS for additional styling */
-                  body {
-                      font-family: 'Open Sans', sans-serif;
-                  }
-
-                  a:hover {
-                      text-decoration: underline;
-                  }
-
-                  .experience-list, .education-list {
-                      list-style-type: square;
-                  }
-              </style>
+              <link rel="stylesheet" href="css/custom.css">
           </head>
           <body class="font-sans bg-gray-100">
               <header class="bg-gray-800 text-white fixed top-0 left-0 w-full z-10">
@@ -112,18 +99,6 @@
                             © Bennett Stouffer. All rights reserved.
                         </footer>
 
-                        <script>
-                            document.addEventListener('DOMContentLoaded', function () {
-                                // Smooth scrolling for anchor links
-                                document.querySelectorAll('a[href^="#"]').forEach(anchor => {
-                                    anchor.addEventListener('click', function (e) {
-                                        e.preventDefault();
-                                        document.querySelector(this.getAttribute('href')).scrollIntoView({
-                                            behavior: 'smooth'
-                                        });
-                                    });
-                                });
-                            });
-                        </script>
+                        <script src="js/scripts.js"></script>
                     </body>
                     </html>

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -11,11 +11,13 @@ document.addEventListener('DOMContentLoaded', function () {
 
     // Example simple form validation (expand as needed)
     const contactForm = document.querySelector('#contact form');
-    contactForm.addEventListener('submit', function (e) {
-        e.preventDefault();
-        // Perform validation checks, e.g., ensure fields are not empty
-        // For demonstration, just log to console
-        console.log('Form submission validated');
-        // Here, you would typically send the form data to a server or email
-    });
+    if (contactForm) {
+        contactForm.addEventListener('submit', function (e) {
+            e.preventDefault();
+            // Perform validation checks, e.g., ensure fields are not empty
+            // For demonstration, just log to console
+            console.log('Form submission validated');
+            // Here, you would typically send the form data to a server or email
+        });
+    }
 });


### PR DESCRIPTION
## Summary
- move inline style rules to a new `css/custom.css`
- link external stylesheet and script from `index.html`
- guard optional contact form logic in `js/scripts.js`

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897f9d9d684833097fd47bb070d1eca