### PR TITLE
Use bullet lists for skills section

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,9 +43,34 @@
 
                   <section id="skills" class="container mx-auto my-8">
                       <h2 class="text-3xl font-bold mb-4">Skills</h2>
-                      <p><strong>Design Tools:</strong> Fusion 360, Inventor, PTC Creo, Solidworks, Cura, Photoshop, Affinity Suite</p>
-                      <p><strong>Practical Skills:</strong> Automation (Industrial and Software), 3D Printing, Electronics Design and Fabrication, Machining (Manual and CNC)</p>
-                      <p><strong>Languages:</strong> Python, C#</p>
+                      <div class="mb-4">
+                          <h3 class="text-xl font-semibold">Design Tools</h3>
+                          <ul class="list-disc ml-8">
+                              <li>Fusion 360</li>
+                              <li>Inventor</li>
+                              <li>PTC Creo</li>
+                              <li>Solidworks</li>
+                              <li>Cura</li>
+                              <li>Photoshop</li>
+                              <li>Affinity Suite</li>
+                          </ul>
+                      </div>
+                      <div class="mb-4">
+                          <h3 class="text-xl font-semibold">Practical Skills</h3>
+                          <ul class="list-disc ml-8">
+                              <li>Automation (Industrial and Software)</li>
+                              <li>3D Printing</li>
+                              <li>Electronics Design and Fabrication</li>
+                              <li>Machining (Manual and CNC)</li>
+                          </ul>
+                      </div>
+                      <div class="mb-4">
+                          <h3 class="text-xl font-semibold">Languages</h3>
+                          <ul class="list-disc ml-8">
+                              <li>Python</li>
+                              <li>C#</li>
+                          </ul>
+                      </div>
                   </section>
 
                   <section id="experience" class="container mx-auto my-8">


### PR DESCRIPTION
## Summary
- Replace paragraph-based skills with bullet lists grouped by category
- Preserve styling with Tailwind classes for headings and lists

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897f9d0800c8330bb4cd3fa5145c9c7