### PR TITLE
Use dark grey theme with light text

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
                   }
               </style>
           </head>
-          <body class="font-sans bg-gray-100">
+          <body class="font-sans bg-gray-900 text-gray-100">
                 <header class="bg-gray-800 text-white fixed top-0 left-0 w-full z-10">
                     <nav aria-label="Primary" class="container mx-auto flex justify-between p-4">
                         <div class="font-bold">Bennett Stouffer</div>
@@ -38,15 +38,15 @@
 
               <main class="pt-16">
                 <section id="about" class="container mx-auto my-8">
-                    <h2 class="text-3xl font-bold mb-4">About Me</h2>
+                    <h2 class="text-3xl font-bold text-gray-100 mb-4">About Me</h2>
                     <img src="/assets/img/profile.jpg" alt="Bennett Stouffer">
                     <p>I am Bennett Stouffer, a dedicated and skilled professional with a passion for design, engineering, and technology. With expertise in design tools, practical skills, and programming languages, I excel in creating innovative solutions and enhancing efficiency in the engineering domain.</p>
                 </section>
 
                   <section id="skills" class="container mx-auto my-8">
-                      <h2 class="text-3xl font-bold mb-4">Skills</h2>
+                      <h2 class="text-3xl font-bold text-gray-100 mb-4">Skills</h2>
                       <div class="mb-4">
-                          <h3 class="text-xl font-semibold">Design Tools</h3>
+                          <h3 class="text-xl font-semibold text-gray-100">Design Tools</h3>
                           <ul class="list-disc ml-8">
                               <li>Fusion 360</li>
                               <li>Inventor</li>
@@ -58,7 +58,7 @@
                           </ul>
                       </div>
                       <div class="mb-4">
-                          <h3 class="text-xl font-semibold">Practical Skills</h3>
+                          <h3 class="text-xl font-semibold text-gray-100">Practical Skills</h3>
                           <ul class="list-disc ml-8">
                               <li>Automation (Industrial and Software)</li>
                               <li>3D Printing</li>
@@ -67,7 +67,7 @@
                           </ul>
                       </div>
                       <div class="mb-4">
-                          <h3 class="text-xl font-semibold">Languages</h3>
+                          <h3 class="text-xl font-semibold text-gray-100">Languages</h3>
                           <ul class="list-disc ml-8">
                               <li>Python</li>
                               <li>C#</li>
@@ -76,10 +76,10 @@
                   </section>
 
                   <section id="experience" class="container mx-auto my-8">
-                      <h2 class="text-3xl font-bold mb-4">Experience</h2>
+                      <h2 class="text-3xl font-bold text-gray-100 mb-4">Experience</h2>
                       <div class="mb-6">
-                          <h3 class="text-xl font-semibold">Design and Manufacturing Engineer, Systemair – Lenexa, KS</h3>
-                          <p class="text-gray-600">Sept 2021 – Present</p>
+                          <h3 class="text-xl font-semibold text-gray-100">Design and Manufacturing Engineer, Systemair – Lenexa, KS</h3>
+                          <p class="text-gray-400">Sept 2021 – Present</p>
                           <ul class="list-disc ml-8">
                               <li>Automated a tedious and dangerous workcell with a six axis robot, allowing for runs of thousands of parts with minimal human interaction.</li>
                               <li>Implemented a new end-of-line tester, which fully automated the test process, protected operators from 1500V shocks, and with the new level of precision catches future returns.</li>
@@ -90,8 +90,8 @@
                           </ul>
                       </div>
                       <div class="mb-6">
-                          <h3 class="text-xl font-semibold">Mechanical Engineer II, Black and Veatch – Overland Park, KS</h3>
-                          <p class="text-gray-600">May 2018 – Sept 2021</p>
+                          <h3 class="text-xl font-semibold text-gray-100">Mechanical Engineer II, Black and Veatch – Overland Park, KS</h3>
+                          <p class="text-gray-400">May 2018 – Sept 2021</p>
                           <ul class="list-disc ml-8">
                               <li>Contributed to the design process for military and intelligence installations.</li>
                               <li>Generated HVAC, chilled water, and plumbing calculations and drawings.</li>
@@ -101,8 +101,8 @@
                           </ul>
                       </div>
                       <div class="mb-6">
-                          <h3 class="text-xl font-semibold">Product Design Intern, Cummins Inc. – Minneapolis, MN</h3>
-                          <p class="text-gray-600">May 2017 – Aug 2017</p>
+                          <h3 class="text-xl font-semibold text-gray-100">Product Design Intern, Cummins Inc. – Minneapolis, MN</h3>
+                          <p class="text-gray-400">May 2017 – Aug 2017</p>
                           <ul class="list-disc ml-8">
                               <li>Led the endurance testing for a RV Engine Generator.</li>
                               <li>Assisted in testing and design decisions.</li>
@@ -112,24 +112,24 @@
                   </section>
 
                   <section id="education" class="container mx-auto my-8">
-                      <h2 class="text-3xl font-bold mb-4">Education</h2>
+                      <h2 class="text-3xl font-bold text-gray-100 mb-4">Education</h2>
                       <p>Cedarville University – Bachelor of Science in Mechanical Engineering, May 2019</p>
                   </section>
 
                   <section id="projects" class="container mx-auto my-8">
-                      <h2 class="text-3xl font-bold mb-4">Projects</h2>
+                      <h2 class="text-3xl font-bold text-gray-100 mb-4">Projects</h2>
                       <div class="mb-6">
-                          <h3 class="text-xl font-semibold">Corn Maze Rake</h3>
+                          <h3 class="text-xl font-semibold text-gray-100">Corn Maze Rake</h3>
                           <p>Designed a pull behind rake for a skid steer loader to knock down dirt piles generated by the tracks while turning. Utilized back of the napkin calculations and drawings to then work with a welder to make a finished product.</p>
                       </div>
                       <div class="mb-6">
-                          <h3 class="text-xl font-semibold">Amateur Game Design</h3>
+                          <h3 class="text-xl font-semibold text-gray-100">Amateur Game Design</h3>
                           <p>Design, prototype, and program basic software and board games in my free time to hone my programming skills and keep the creative juices flowing.</p>
                       </div>
                   </section>
 
                   <section id="contact" class="container mx-auto my-8">
-                      <h2 class="text-3xl font-bold mb-4">Contact</h2>
+                      <h2 class="text-3xl font-bold text-gray-100 mb-4">Contact</h2>
                       <p>Email: <a href="mailto:bennettstouffer@gmail.com" class="text-blue-500 hover:underline">bennettstouffer@gmail.com</a></p>
                     <p>Phone: <a href="tel:+18165728930" class="text-blue-500 hover:underline">816-572-8930</a></p>
                             </section>


### PR DESCRIPTION
## Summary
- switch site to dark grey background with light text for a traditional dark mode
- lighten all section and subsection headings for readability
- adjust date colors in experience section for contrast

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897fc79ee0083309dcd8a536fea1939