### PR TITLE
Add responsive navigation menu toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,16 +23,21 @@
           </head>
           <body class="font-sans bg-gray-900 text-gray-100">
                 <header class="bg-gray-800 text-white fixed top-0 left-0 w-full z-10">
-                    <nav aria-label="Primary" class="container mx-auto flex justify-between p-4">
+                    <nav aria-label="Primary" class="container mx-auto flex justify-between items-center p-4">
                         <div class="font-bold">Bennett Stouffer</div>
-                        <ul class="flex list-none items-center">
-                            <li><a href="#about" class="px-4 hover:underline">About</a></li>
-                            <li><a href="#skills" class="px-4 hover:underline">Skills</a></li>
-                            <li><a href="#experience" class="px-4 hover:underline">Experience</a></li>
-                            <li><a href="#education" class="px-4 hover:underline">Education</a></li>
-                            <li><a href="#projects" class="px-4 hover:underline">Projects</a></li>
-                            <li><a href="#contact" class="px-4 hover:underline">Contact</a></li>
-                        </ul>
+                        <div id="menu" class="hidden md:block">
+                            <ul class="flex list-none items-center">
+                                <li><a href="#about" class="px-4 hover:underline">About</a></li>
+                                <li><a href="#skills" class="px-4 hover:underline">Skills</a></li>
+                                <li><a href="#experience" class="px-4 hover:underline">Experience</a></li>
+                                <li><a href="#education" class="px-4 hover:underline">Education</a></li>
+                                <li><a href="#projects" class="px-4 hover:underline">Projects</a></li>
+                                <li><a href="#contact" class="px-4 hover:underline">Contact</a></li>
+                            </ul>
+                        </div>
+                        <button id="menu-btn" class="md:hidden focus:outline-none">
+                            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
+                        </button>
                     </nav>
               </header>
 

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -9,4 +9,15 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     });
 
+    // Toggle navigation menu on small screens
+    const menuBtn = document.getElementById('menu-btn');
+    const menu = document.getElementById('menu');
+
+    if (menuBtn && menu) {
+        menuBtn.addEventListener('click', () => {
+            menu.classList.toggle('hidden');
+            menu.classList.toggle('block');
+        });
+    }
+
 });


### PR DESCRIPTION
## Summary
- Wrap navigation links in a hideable container
- Add hamburger button to toggle menu on small screens
- Include script to toggle hidden/block classes for responsive nav

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d3c3263a083308ae83be46ef8f949