### PR TITLE
Add basic Jest setup and menu toggle test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -1,3 +1,8 @@
+function toggleMenu(menu) {
+    menu.classList.toggle('hidden');
+    menu.classList.toggle('block');
+}
+
 document.addEventListener('DOMContentLoaded', function () {
     // Smooth scrolling for anchor links
     document.querySelectorAll('a[href^="#"]').forEach(anchor => {
@@ -15,9 +20,11 @@ document.addEventListener('DOMContentLoaded', function () {
 
     if (menuBtn && menu) {
         menuBtn.addEventListener('click', () => {
-            menu.classList.toggle('hidden');
-            menu.classList.toggle('block');
+            toggleMenu(menu);
         });
     }
-
 });
+
+if (typeof module !== 'undefined') {
+    module.exports = { toggleMenu };
+}

--- a/js/scripts.test.js
+++ b/js/scripts.test.js
@@ -1,0 +1,10 @@
+const { JSDOM } = require('jsdom');
+const { toggleMenu } = require('./scripts.js');
+
+test('toggleMenu switches hidden and block classes', () => {
+  const dom = new JSDOM(`<!DOCTYPE html><div id="menu" class="hidden"></div>`);
+  const menu = dom.window.document.getElementById('menu');
+  toggleMenu(menu);
+  expect(menu.classList.contains('hidden')).toBe(false);
+  expect(menu.classList.contains('block')).toBe(true);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "bennetster-site",
+  "version": "1.0.0",
+  "description": "Static site with tests",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^24.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add package.json and .gitignore to support npm testing
- expose `toggleMenu` helper and test class toggling with Jest

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f40212f3c8330a066774b29a48531